### PR TITLE
Cache the node path lookup

### DIFF
--- a/find-node.sh
+++ b/find-node.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+if [[ -z "$alfred_workflow_cache" ]]; then
+	echo "This script must be called from Alfred"
+	exit 1
+fi
+
+if [[ ! -d "$alfred_workflow_cache" ]]; then
+    mkdir -p "$alfred_workflow_cache"
+fi
+
+PATH_CACHE="$alfred_workflow_cache"/node_path
+
+get_user_path() {
+    eval $(/usr/libexec/path_helper -s)
+    echo "$($SHELL -i -l -c 'echo -e "\n"PATH=\"$PATH:\$PATH\""\n"' 2>/dev/null | grep "^PATH=")" > "$PATH_CACHE"
+}
+
+set_path() {
+    if [[ -f "$PATH_CACHE" ]]; then
+        . "$PATH_CACHE"
+    else
+        get_user_path
+        . "$PATH_CACHE"
+    fi
+
+    export PATH
+}
+
+has_node() {
+    command -v node >/dev/null 2>&1
+}
+
+# Check if we have node, otherwise inherit path from user shell
+if ! has_node; then
+    set_path
+
+    # Retry by deleting old path cache
+    if ! has_node; then
+        rm "$PATH_CACHE"
+        set_path
+    fi
+fi
+
+if has_node; then
+	node "$1" "$2"
+else
+	echo $'{"items":[{"title": "Couldn\'t find the `node` binary", "subtitle": "Symlink it to `/usr/local/bin`"}]}'
+fi

--- a/info.plist
+++ b/info.plist
@@ -71,15 +71,7 @@
 				<key>runningsubtext</key>
 				<string>Searching...</string>
 				<key>script</key>
-				<string>eval $(/usr/libexec/path_helper -s)
-eval "$($SHELL -i -l -c 'echo -e "\n"PATH=\"$PATH:\$PATH\""\n"' 2&gt;/dev/null | grep "^PATH=")"
-export PATH
-
-if command -v node &gt;/dev/null 2&gt;&amp;1; then
-	node index.js "$1"
-else
-	echo $'{"items":[{"title": "Couldn\'t find the `node` binary", "subtitle": "Symlink it to `/usr/local/bin`"}]}'
-fi</string>
+				<string>./find-node.sh index.js "$1"</string>
 				<key>scriptargtype</key>
 				<integer>1</integer>
 				<key>scriptfile</key>


### PR DESCRIPTION
I was wondering why `git` was firing up every time I typed something in `alfred-emoj`, so here's my suggested solution:

Avoid starting up a complete login shell on every execution, if at any point `node` can no longer be found, the cache is invalidated and we make a new attempt at finding it.
- Stores cache in `.path_cache` (inside workflow directory)
- Does nothing special if `node` is found
- Tries to use cache (for path) if it exists
- Refresh cache if `node` is not found

In most cases there probably won't be a significant speedup from this, but less work is less work.
